### PR TITLE
Gmt 6

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,6 @@ COPY . .
 
 EXPOSE 3000
 
+ENV TZ="America/Mexico_City"
+
 CMD ["npm", "start"]

--- a/backend/config/database.config.js
+++ b/backend/config/database.config.js
@@ -3,15 +3,25 @@ import "dotenv/config";
 import mysql from "mysql2/promise";
 import { seedDatabase } from "../utils/seed.utils.js";
 
-const DB_NAME = process.env.DB_NAME || "barberia";
+const DB_NAME = process.env.DB_NAME || "barbershop";
+const TIMEZONE = "-06:00"; // GMT-6
 const DB_USER = process.env.DB_USER || "root";
 const DB_PASSWORD = process.env.DB_PASSWORD || "";
 const DB_HOST = process.env.DB_HOST || "localhost";
 const TIMEOUT = process.env.TIMEOUT || 20000;
+
+/**
+ * IMPORTANT: To store dates as GMT-6 in the database:
+ * Always create dates with explicit timezone offset: new Date("2024-12-03T14:00:00-06:00")
+ */
 export const sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
   host: DB_HOST,
   dialect: "mysql",
-  logging: true,
+  logging: console.log,
+  timezone: TIMEZONE, // Tells Sequelize to convert UTC to GMT-6 when writing to DB
+  dialectOptions: {
+    timezone: TIMEZONE, // Sets MySQL session: SET time_zone = '-06:00'
+  },
 });
 
 export async function initDB() {

--- a/backend/index.js
+++ b/backend/index.js
@@ -46,6 +46,8 @@ async function startServer() {
     app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });
+    console.log("TZ:", process.env.TZ);
+    console.log("Now:", new Date().toString());
   } catch (error) {
     console.error("Error starting server:", error);
     process.exit(1);

--- a/backend/tests/appointment/appointment.timezone.test.js
+++ b/backend/tests/appointment/appointment.timezone.test.js
@@ -3,10 +3,7 @@ import { QueryTypes } from "sequelize";
 import { sequelize } from "../../config/database.config.js";
 import { Appointment } from "../../models/appointment.model.js";
 import { Barber } from "../../models/barber.model.js";
-import {
-  formatDateForTimezone,
-  parseOffsetMinutes,
-} from "../../utils/appointment.utils.js";
+import { formatDateForTimezone } from "../../utils/appointment.utils.js";
 
 const DB_TIMEZONE = "-06:00"; // GMT-06:00 offset enforced on the DB session
 
@@ -47,9 +44,6 @@ describe("Appointment Timezone", () => {
     );
 
     expect(session_tz).toBe(DB_TIMEZONE);
-    expect(parseOffsetMinutes(session_tz)).toBe(
-      parseOffsetMinutes(DB_TIMEZONE)
-    );
   });
 
   it("stores UTC appointment datetimes converted to GMT-06:00", async () => {

--- a/backend/tests/appointment/appointment.timezone.test.js
+++ b/backend/tests/appointment/appointment.timezone.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { QueryTypes } from "sequelize";
+import { sequelize } from "../../config/database.config.js";
+import { Appointment } from "../../models/appointment.model.js";
+import { Barber } from "../../models/barber.model.js";
+import {
+  formatDateForTimezone,
+  parseOffsetMinutes,
+} from "../../utils/appointment.utils.js";
+
+const DB_TIMEZONE = "-06:00"; // GMT-06:00 offset enforced on the DB session
+
+let testBarber;
+
+async function fetchStoredDateString(appointmentId) {
+  const rows = await sequelize.query(
+    "SELECT DATE_FORMAT(appointment_datetime, '%Y-%m-%d %H:%i:%s') AS `date` FROM appointment WHERE id = ?",
+    { replacements: [appointmentId], type: QueryTypes.SELECT }
+  );
+  return rows[0]?.date;
+}
+
+beforeAll(async () => {
+  testBarber = await Barber.create({
+    barber_name: "Test Barber",
+    image_path: "test.jpg",
+    is_active: true,
+    email: "testbarber@example.com",
+    phone: "1234567890",
+  });
+});
+
+afterAll(async () => {
+  if (testBarber) {
+    await testBarber.destroy();
+  }
+  await sequelize.close();
+});
+
+describe("Appointment Timezone", () => {
+  it("keeps Sequelize and the DB session locked to GMT-06:00", async () => {
+    expect(sequelize.options.timezone).toBe(DB_TIMEZONE);
+
+    const [{ session_tz }] = await sequelize.query(
+      "SELECT @@session.time_zone AS session_tz",
+      { type: QueryTypes.SELECT }
+    );
+
+    expect(session_tz).toBe(DB_TIMEZONE);
+    expect(parseOffsetMinutes(session_tz)).toBe(
+      parseOffsetMinutes(DB_TIMEZONE)
+    );
+  });
+
+  it("stores UTC appointment datetimes converted to GMT-06:00", async () => {
+    const appointment_datetime = new Date("2024-12-02T18:00:00.000Z");
+    const expectedStored = formatDateForTimezone(
+      appointment_datetime,
+      DB_TIMEZONE
+    );
+
+    const testAppointment = await Appointment.create({
+      customer_name: "John Doe",
+      customer_phone: "5551234567",
+      customer_email: "john@example.com",
+      appointment_datetime,
+      total_duration: 30,
+      status: "pending",
+      barber_id: testBarber.id,
+    });
+
+    try {
+      const stored = await fetchStoredDateString(testAppointment.id);
+      expect(stored).toBe(expectedStored);
+    } finally {
+      await testAppointment.destroy();
+    }
+  });
+
+  it("normalizes incoming non-GMT-06:00 offsets to GMT-06:00 before saving", async () => {
+    const appointment_datetime = new Date("2024-12-02T09:15:00+02:00");
+    const expectedStored = formatDateForTimezone(
+      appointment_datetime,
+      DB_TIMEZONE
+    );
+
+    const testAppointment = await Appointment.create({
+      customer_name: "Jane Smith",
+      customer_phone: "5559876543",
+      customer_email: "jane@example.com",
+      appointment_datetime,
+      total_duration: 45,
+      status: "pending",
+      barber_id: testBarber.id,
+    });
+
+    try {
+      const stored = await fetchStoredDateString(testAppointment.id);
+      expect(stored).toBe(expectedStored);
+    } finally {
+      await testAppointment.destroy();
+    }
+  });
+});

--- a/backend/utils/appointment.utils.js
+++ b/backend/utils/appointment.utils.js
@@ -1,9 +1,115 @@
+/**
+ * Sets the time portion of a date object based on a time string.
+ * Takes a date and time string (HH:MM or HH:MM:SS) and returns a new date
+ * with the time components replaced.
+ *
+ * @param {Date} date - The base date to modify
+ * @param {string} timeStr - Time string in format HH:MM or HH:MM:SS (e.g., "14:30" or "14:30:45")
+ * @returns {Date} A new date object with updated time, milliseconds zeroed
+ *
+ * Performance note: Uses single setHours() call instead of multiple setHours/setMinutes/setSeconds
+ * calls to minimize date mutations (was 4 operations, now 1).
+ */
 export function setTimeToDate(date, timeStr) {
-  const [hours, minutes, seconds] = timeStr.split(':').map(Number);
+  
+  if (!(date instanceof Date) || isNaN(date)) {
+    throw new Error("Invalid date provided");
+  }
+  
+  if (typeof timeStr !== "string" || !timeStr.trim()) {
+    throw new Error("Invalid time string provided");
+  }
+
+  // Parse time components using destructuring with default for optional seconds
+  const [hours, minutes, seconds = "0"] = timeStr.split(":");
   const newDate = new Date(date);
-  newDate.setHours(hours);
-  newDate.setMinutes(minutes);
-  newDate.setSeconds(seconds || 0);
-  newDate.setMilliseconds(0);
+  newDate.setHours(Number(hours), Number(minutes), Number(seconds), 0);
   return newDate;
+}
+
+/**
+ * PERFORMANCE OPTIMIZATION: Regex pattern cached at module level
+ *
+ * By caching it here, we compile once and reuse the same pattern object.
+ * Matches timezone offset strings like "+05:30" or "-06:00"
+ */
+const OFFSET_REGEX = /^([+-])(\d{2}):(\d{2})$/;
+
+/**
+ * Converts a timezone offset string to total minutes.
+ * Useful for time arithmetic and database timezone conversions.
+ *
+ * @param {string} [offsetStr="-06:00"] - Offset string in format ±HH:MM (e.g., "-06:00", "+05:30")
+ * @returns {number} Total offset in minutes (negative for west, positive for east)
+ *
+ * Examples:
+ *   parseOffsetMinutes() => -360 (default)
+ *   parseOffsetMinutes("+05:30") => 330
+ */
+export function parseOffsetMinutes(offsetStr = "-06:00") {
+  
+  const match = OFFSET_REGEX.exec(offsetStr);
+  if (!match) throw new Error(`Invalid offset format: ${offsetStr}`);
+
+  // Convert sign to multiplier (-1 for west, +1 for east)
+  const sign = match[1] === "-" ? -1 : 1;
+  // Extract hours and minutes, convert to total minutes with sign
+  const offsetMinutes = sign * (Number(match[2]) * 60 + Number(match[3]));
+  return offsetMinutes;
+}
+
+/**
+ * PERFORMANCE OPTIMIZATION: Padding function cached at module level
+ *
+ * Previously, this was defined inside formatDateForTimezone() and recreated
+ * on every function call. This caused:
+ * - Function object allocation on each call
+ * - Closure allocation for each invocation
+ * - Repeated garbage collection of unused function objects
+ *
+ * By defining once at module level, we have a single reusable function reference.
+ */
+const PAD_ZERO = (value) => String(value).padStart(2, "0");
+
+/**
+ * Converts a date to a formatted string in a specific timezone offset.
+ * Useful for consistent database storage and API responses.
+ *
+ * @param {Date|string|number} dateInput - Date to format (accepts any Date constructor argument)
+ * @param {string} [offsetStr="-06:00"] - Timezone offset in format ±HH:MM (e.g., "-06:00", "+02:00")
+ * @returns {string} Formatted date string "YYYY-MM-DD HH:MM:SS" adjusted to the specified timezone
+ *
+ * Examples:
+ *   formatDateForTimezone(new Date("2024-12-02T18:00:00Z"), "-06:00")
+ *   // Returns: "2024-12-02 12:00:00" (UTC-6 = 6 hours behind)
+ *
+ * How it works:
+ * 1. Parse the timezone offset to minutes
+ * 2. Create a date object from input
+ * 3. Adjust the date by adding offset minutes (converts UTC to local time)
+ * 4. Format using UTC getters to prevent double conversion
+ */
+export function formatDateForTimezone(dateInput, offsetStr = "-06:00") {
+  const offsetMinutes = parseOffsetMinutes(offsetStr);
+  // Create date once (optimization: avoid double new Date() calls)
+  const date = new Date(dateInput);
+
+  if (isNaN(date.getTime())) {
+    throw new Error("Invalid date provided");
+  }
+
+  // Adjust date by adding the offset minutes (in milliseconds)
+  // This shifts UTC time to the target timezone for display
+  const adjusted = new Date(date.getTime() + offsetMinutes * 60 * 1000);
+
+  // Build formatted string with zero-padded components
+  // Using string concatenation for better readability than template literals
+  return (
+    `${adjusted.getUTCFullYear()}-` +
+    `${PAD_ZERO(adjusted.getUTCMonth() + 1)}-` +
+    `${PAD_ZERO(adjusted.getUTCDate())} ` +
+    `${PAD_ZERO(adjusted.getUTCHours())}:` +
+    `${PAD_ZERO(adjusted.getUTCMinutes())}:` +
+    `${PAD_ZERO(adjusted.getUTCSeconds())}`
+  );
 }

--- a/backend/utils/appointment.utils.js
+++ b/backend/utils/appointment.utils.js
@@ -37,7 +37,7 @@ const OFFSET_REGEX = /^([+-])(\d{2}):(\d{2})$/;
 
 /**
  * Converts a timezone offset string to total minutes.
- * Useful for time arithmetic and database timezone conversions.
+ * Database timezone conversions.
  *
  * @param {string} [offsetStr="-06:00"] - Offset string in format ±HH:MM (e.g., "-06:00", "+05:30")
  * @returns {number} Total offset in minutes (negative for west, positive for east)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: barberia
+      TZ: America/Mexico_City
+    command: 
+      - --default-time-zone=-06:00
     ports:
       - 3306:3306
     volumes:


### PR DESCRIPTION
**Timezone Handling and Configuration**

* Updated `backend/config/database.config.js` to set Sequelize and MySQL session timezone to GMT-06:00, ensuring all database writes and reads use the correct offset. Added comments and configuration for explicit timezone management.
* Docker and Docker Compose files now set the `TZ` environment variable and MySQL's default time zone to America/Mexico_City / -06:00, aligning container and database environments.

**Utility Functions and Appointment Normalization**

* Added new utility functions in `backend/utils/appointment.utils.js` for parsing timezone offsets and formatting dates for a specific timezone. These are now used throughout appointment creation, update, and querying to normalize all datetimes to GMT-06:00 before saving or filtering.
* Refactored `backend/repositories/appointment.repository.js` to use `formatDateForTimezone` for all appointment datetime operations, ensuring consistent timezone normalization for filtering, creation, updates, and overlap checks. 

**Database Seeding and Testing**

* Modified the seeding logic in `backend/utils/seed.utils.js` to convert all seeded appointment datetimes to GMT-06:00 format, guaranteeing consistency in test and development environments. 
* Added a new test suite `backend/tests/appointment/appointment.timezone.test.js` to verify that both Sequelize and the database session are locked to GMT-06:00, and that all stored appointment datetimes are correctly normalized regardless of input timezone.
