### PR TITLE
Establishment Migrations

### DIFF
--- a/backend/utils/seed.production.util.js
+++ b/backend/utils/seed.production.util.js
@@ -95,9 +95,10 @@ export async function seed(transaction = null) {
 
     const barber = await Barber.create(
       {
-        barber_name: "Barbero Principal",
+        barber_name: "Ricardo",
         is_active: true,
         establishment_id: establishment.id,
+        account_id: adminAccount.id,
       },
       { transaction: t },
     );

--- a/frontend/src/app/admin/accounts/client.jsx
+++ b/frontend/src/app/admin/accounts/client.jsx
@@ -61,6 +61,7 @@ export default function IndexAccounts(){
     async function load() {
       try{
         const accs = await getAccounts();
+        if (accs.length == 0 )  setMessage('No se han registrado cuentas en el sistema');
         setAccounts(accs);
       } catch (e) {
         setMessage(e);

--- a/frontend/src/app/admin/appointments/client.jsx
+++ b/frontend/src/app/admin/appointments/client.jsx
@@ -26,6 +26,7 @@ export default function Appointments({isAdmin}) {
       const fetchAppointments = async () => {
         try {
           const data = await getAppointments();
+          if (data.length == 0 )  setMessage('No se han registrado citas');
           setAppointments(data);
         } catch (error) {
           setMessage('No se pudieron recuperar las citas');

--- a/frontend/src/app/admin/establishments/client.jsx
+++ b/frontend/src/app/admin/establishments/client.jsx
@@ -15,7 +15,7 @@ import SearchGrid from "@/app/components/base_layout/SearchGrid";
 
 export default function IndexEstablishment(){
   const [establishments, setEstablishments] = useState(null)
-  const [ message, setMessage] = useState('No se han registrado los establecimentos');
+  const [ message, setMessage] = useState('Cargando ...');
   const [gridApi, setGridApi] = useState(null);
   const gridRef = useRef();
 
@@ -44,6 +44,7 @@ export default function IndexEstablishment(){
     const load = async () => {
       try {
         const response = await getEstablishments();
+        if (response.length == 0 )  setMessage('No se han registrado los establecimentos');
         setEstablishments(response);
       } catch (e) {
         setMessage('No se pudieron cargar los establecimientos')

--- a/frontend/src/app/admin/services/client.jsx
+++ b/frontend/src/app/admin/services/client.jsx
@@ -28,11 +28,13 @@ export default function Services({isAdmin, establishment_id}) {
 
 
   useEffect(() => {
+    setMessage('Cargando ...');
     const fetch = async() =>{
       try{
         let data;
         if (isAdmin) data = await getServices();
         else data = await getServicesByEstablishment(establishment_id);
+        if (data.length == 0 )  setMessage('No se han registrado los servicios');
         setServices(data);
         
       }catch(err){

--- a/frontend/src/app/admin/staff/client.jsx
+++ b/frontend/src/app/admin/staff/client.jsx
@@ -23,12 +23,13 @@ export default function StaffIndex({isAdmin, establishmentId}) {
   const gridRef = useRef();
   
   useEffect(() => {
-    setMessage('No se han registrado los servicios');
+    setMessage('Cargando ...');
     const fetch = async () => {
       try{
         let data;
         if (isAdmin) data = await getEmployees();
         else data = await getEmployeesByEstablishment(establishmentId);
+        if (data.data.length == 0 )  setMessage('No se han registrado los empleados');
         setEmployees(data.data);
 
       }catch (err){

--- a/frontend/src/app/apiHandlers/adminServices.js
+++ b/frontend/src/app/apiHandlers/adminServices.js
@@ -11,7 +11,7 @@ import { redirect } from "next/navigation";
 export const getServices = async () => {
   try {
     const headers = axiosConfig();
-    const request = await axios.get(getServicesApiRoute+'?limit=99', headers);
+    const request = await axios.get(getServicesApiRoute, headers);
     const data = request.data.data;
     return data;
   } catch (error) {


### PR DESCRIPTION
This pull request introduces several improvements to user feedback messaging and data handling across the admin frontend, as well as a small adjustment in backend seeding logic. The main focus is on providing clearer loading and empty-state messages for lists of accounts, appointments, establishments, services, and staff, ensuring users are better informed about the state of the data. Additionally, there is a minor update to backend seed data and a change in the API request logic for services.

**User feedback improvements (frontend):**

* Changed default messages to "Cargando ..." (Loading ...) when data is being fetched for establishments and staff, replacing previous empty-state messages. (`frontend/src/app/admin/establishments/client.jsx`, `frontend/src/app/admin/staff/client.jsx`) [[1]](diffhunk://#diff-e93fe21c57ee5a488bbfd793eebbd0d02b28ef7c0ff23a3230488f306d3b1e2dL18-R18) [[2]](diffhunk://#diff-06c56bc4037c557e370e20c1624919620e98c32bb573075014fef3b23c290b9aL26-R32)
* Added empty-state messages for accounts, appointments, establishments, services, and staff when no data is found after fetching. (`frontend/src/app/admin/accounts/client.jsx`, `frontend/src/app/admin/appointments/client.jsx`, `frontend/src/app/admin/establishments/client.jsx`, `frontend/src/app/admin/services/client.jsx`, `frontend/src/app/admin/staff/client.jsx`) [[1]](diffhunk://#diff-9147e40a6eb000c2293836f23c8dc3dd0a9da93e9517315205d46e0a80313774R64) [[2]](diffhunk://#diff-b138b48ca92394f93a59aea2a52b636383433577cc007a0eba205d93dbfbe8b5R29) [[3]](diffhunk://#diff-e93fe21c57ee5a488bbfd793eebbd0d02b28ef7c0ff23a3230488f306d3b1e2dR47) [[4]](diffhunk://#diff-b149ef6114442f537e2a70901effd5a84b6dea3227b6d2838ed759233617fe2dR31-R37) [[5]](diffhunk://#diff-06c56bc4037c557e370e20c1624919620e98c32bb573075014fef3b23c290b9aL26-R32)

**Backend and API adjustments:**

* Updated the `Barber` seed data to use the name "Ricardo" and associate it with an `account_id`. (`backend/utils/seed.production.util.js`)
* Modified the `getServices` API handler to remove the `limit=99` query parameter, now fetching all services without a limit. (`frontend/src/app/apiHandlers/adminServices.js`)